### PR TITLE
Update git url for prometheus-boshrelease and node-exporter-boshrelease

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -318,8 +318,8 @@
 - url: https://github.com/cloudfoundry-community/sawmill-boshrelease
 - url: https://github.com/SAP/ipsec-release
   min_version: 3
-- url: https://github.com/cloudfoundry-community/prometheus-boshrelease
-- url: https://github.com/cloudfoundry-community/node-exporter-boshrelease
+- url: https://github.com/bosh-prometheus/prometheus-boshrelease
+- url: https://github.com/bosh-prometheus/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease
 - url: https://github.com/cloudfoundry-incubator/garden-windows-bosh-release
 - url: https://github.com/cloudfoundry/grootfs-release


### PR DESCRIPTION
prometheus-boshrelease and node-exporter-boshrelease have moved a while ago to bosh-prometheus gh org

See related slack thread https://cloudfoundry.slack.com/archives/C02FL4A2K/p1707488086281179?thread_ts=1707462526.630869&cid=C02FL4A2K

