### PR TITLE
move-prometheus-boshreleas-to-cloudfoundry

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -318,7 +318,7 @@
 - url: https://github.com/cloudfoundry-community/sawmill-boshrelease
 - url: https://github.com/SAP/ipsec-release
   min_version: 3
-- url: https://github.com/bosh-prometheus/prometheus-boshrelease
+- url: https://github.com/cloudfoundry/prometheus-boshrelease
 - url: https://github.com/bosh-prometheus/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease
 - url: https://github.com/cloudfoundry-incubator/garden-windows-bosh-release

--- a/index.yml
+++ b/index.yml
@@ -319,7 +319,7 @@
 - url: https://github.com/SAP/ipsec-release
   min_version: 3
 - url: https://github.com/cloudfoundry/prometheus-boshrelease
-- url: https://github.com/bosh-prometheus/node-exporter-boshrelease
+- url: https://github.com/cloudfoundry/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease
 - url: https://github.com/cloudfoundry-incubator/garden-windows-bosh-release
 - url: https://github.com/cloudfoundry/grootfs-release

--- a/index.yml
+++ b/index.yml
@@ -318,6 +318,8 @@
 - url: https://github.com/cloudfoundry-community/sawmill-boshrelease
 - url: https://github.com/SAP/ipsec-release
   min_version: 3
+- url: https://github.com/bosh-prometheus/prometheus-boshrelease
+- url: https://github.com/bosh-prometheus/node-exporter-boshrelease
 - url: https://github.com/cloudfoundry/prometheus-boshrelease
 - url: https://github.com/cloudfoundry/node-exporter-boshrelease
 - url: https://github.com/frodenas/dex-boshrelease


### PR DESCRIPTION
prometheus-boshrelease has moved  from bosh-prometheus gh org to cloudfoundry gh org
