### PR TITLE
remove telemtry release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -387,7 +387,6 @@
   min_version: 1.0
 - url: https://github.com/cloudfoundry/service-logs-release
   min_version: 1.0
-- url: https://github.com/pivotal-cf/telemetry-release
 - url: https://github.com/cloudfoundry-incubator/notifications-release
   min_version: 2.0
 - url: https://github.com/cloudfoundry-incubator/event-log-release


### PR DESCRIPTION
* we no longer can pull blobs for this release

Checklist for submission:

- [ ] LICENSE and NOTICE files are up to date
- [ ] at least one final release is checked in on the default repo branch (there's a `.final_builds` folder)
- [ ] of use to the general community and will be maintained
- [ ] github repo must be public
- [ ] bosh create-release must run successfully against all final releases (the blobstore needs to be public)
  - if not all final releases are valid, specify a `min_version`
- [ ] a README explaining what the repo does
- [ ] [optional] deployment manifests/ directory contains example manifest
