### PR TITLE
Add cloudfoundry/cflinuxfs5-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -85,6 +85,8 @@
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/cflinuxfs4-release
   categories: [cf-core]
+- url: https://github.com/cloudfoundry/cflinuxfs5-release
+  categories: [cf-core]
 - url: https://github.com/cloudfoundry-incubator/windows2016fs-online-release
   categories: [cf-core]
 - url: https://github.com/cloudfoundry/windows1803fs-online-release


### PR DESCRIPTION
## Summary
- Adds [cloudfoundry/cflinuxfs5-release](https://github.com/cloudfoundry/cflinuxfs5-release) to the index in the `cf-core` category, alongside the existing cflinuxfs2/3/4 releases.

## Checklist
- [x] GitHub repo is public
- [x] Release is from the cloudfoundry org and maintained by the community
- [x] Repository has a README